### PR TITLE
Search NDI lib in default lib paths on linux

### DIFF
--- a/Pinvoke/NDIlib.cs
+++ b/Pinvoke/NDIlib.cs
@@ -88,8 +88,8 @@ public static partial class NDIlib
 
 	private static nint ResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
 	{
-		var libName = string.Empty;
-        var useAlternateLoadLogic = false;
+		string libName;
+		var useAlternateLoadLogic = false;
 
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
@@ -108,7 +108,7 @@ public static partial class NDIlib
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 		{
-            useAlternateLoadLogic = true;
+			useAlternateLoadLogic = true;
 			libName = "libndi.so";
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -120,24 +120,27 @@ public static partial class NDIlib
 			throw new NotImplementedException($"{RuntimeInformation.OSDescription} not supported.");
 		}
 
-        var handle = nint.Zero;
+        nint handle;
 
-        if(useAlternateLoadLogic)
+        if (NativeLibrary.TryLoad(libName, out handle))
+        {
+            return handle;
+        }
+
+        if (useAlternateLoadLogic)
         {
             var libPath = Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory,
                 libName
             );
 
-            NativeLibrary.TryLoad(libPath, out handle);
-        }
-        else
-        {
-    		NativeLibrary.TryLoad(libName, out handle);
+            if (NativeLibrary.TryLoad(libPath, out handle))
+            {
+                return handle;
+            }
         }
 
-
-		return handle;
+        return nint.Zero;
     }
 } // namespace NewTek
 

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ NDI® is a registered trademark of Vizrt.
 
 ### Linux Notes
 
-`libndi.so` is searched for in the app launch path. Make sure the correct library for your platform is copied there.
+`libndi.so` is searched for in the `PATH` environment variable and the app launch path.
+If the SDK is not installed correctly, it might be necessary to copy / link `libndi.so` to the app launch path.
 


### PR DESCRIPTION
Try searching libndi in default lib paths (e.g. in `/usr/lib/libndi.so`), before resorting to checking the application directory.
This way, no manual copying is required when the NDI SDK is installed correctly.